### PR TITLE
The data-mapper gem requires ruby 2.0 or higher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM ubuntu
 MAINTAINER Johan Haals <johan@haals.se>
 
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y supervisor ruby mumble-server libsqlite3-dev ruby-dev build-essential
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y supervisor ruby2.0 mumble-server libsqlite3-dev ruby2.0-dev build-essential
 
-RUN gem install data_mapper --no-rdoc --no-ri
-RUN gem install dm-sqlite-adapter --no-rdoc --no-ri
+RUN gem2.0 install data_mapper --no-rdoc --no-ri
+RUN gem2.0 install dm-sqlite-adapter --no-rdoc --no-ri
 
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 ADD start.sh /

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
-ruby /mumble.rb
+ruby2.0 /mumble.rb
 /usr/bin/supervisord


### PR DESCRIPTION
Just made some reference changes - seems to work now once we use ruby 2.0.